### PR TITLE
Tailwind example and basic documentation

### DIFF
--- a/guides/Tailwind.md
+++ b/guides/Tailwind.md
@@ -1,0 +1,23 @@
+## Using Tailwind
+
+This is an example on how to pass the `tailwind` cdn to be inserted as a `<head>` script.
+
+```
+Mix.install([
+  {:liveview_playground, "~> 0.1.1"}
+])
+
+defmodule PageLive do
+  use LiveviewPlaygroundWeb, :live_view
+
+  def render(assigns) do
+    ~H"""
+    <h1 class="text-3xl font-bold underline">
+      Hello world!
+    </h1>
+    """
+  end
+end
+
+LiveviewPlayground.start(scripts: ["https://cdn.tailwindcss.com"])
+```

--- a/lib/liveview_playground.ex
+++ b/lib/liveview_playground.ex
@@ -4,12 +4,15 @@ defmodule LiveviewPlayground do
   """
 
   @doc """
-  Hello world.
+  Starts liveview playground
 
-  ## Examples
+  All options are optional. They are:
 
-      iex> LiveviewPlayground.hello()
-      :world
+    * `:router` - the Phoenix.Router module
+
+    * `:endpoint` - the Phoenix.Endpoint module
+
+    * `:script` - list of binaries that will be included as scripts on the layout <head>
 
   """
   def start(opts \\ []) do
@@ -31,8 +34,4 @@ defmodule LiveviewPlayground do
     {:ok, _} = Supervisor.start_link([endpoint], strategy: :one_for_one)
     Process.sleep(:infinity)
   end
-
-  # def make_endpoint(router) do
-  #   LiveviewPlayground.Endpoint
-  # end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule LiveviewPlayground.MixProject do
         # The main page in the docs
         main: "readme",
         # logo: "path/to/logo.png",
-        extras: ["README.md", "guides/Number Counter.md", "guides/Custom Router.md"],
+        extras: ["README.md", "guides/Number Counter.md", "guides/Custom Router.md", "guides/Tailwind.md"],
         groups_for_extras: groups_for_extras()
       ]
     ]


### PR DESCRIPTION
- Add Tailwind example to the documentation.
- Refactor LiveviewPlayground.start/1 doc to remove "Hello world" example.